### PR TITLE
switch to WPCOM OpenAI proxy endpoint

### DIFF
--- a/script.js
+++ b/script.js
@@ -189,7 +189,7 @@ async function openaiCall( token, model, prompt, replacements = {}, temperature 
     };
 
     try {
-        const response = await fetch( 'https://api.openai.com/v1/chat/completions', requestOptions );
+        const response = await fetch( 'https://public-api.wordpress.com/wpcom/v2/openai-proxy/v1/chat/completions', requestOptions );
         const data = await response.json();
         console.log( data );
         if (data.choices && data.choices.length > 0) {


### PR DESCRIPTION
We have a new official endpoint for all OpenAI API integration, hosted at https://public-api.wordpress.com/wpcom/v2/openai-proxy/v1.

This patch brute-force switches all direct references to the OpenAI endpoints to the new URL. You may reuse your existing OpenAI tokens with the endpoint for now.

If this repo is no longer in use, feel free to close this PR 😃 